### PR TITLE
Moved Error Controller route to right after plugins custom routes.

### DIFF
--- a/ckan/config/routing.py
+++ b/ckan/config/routing.py
@@ -86,6 +86,10 @@ def make_map():
     map.minimization = False
     map.explicit = True
 
+    # CUSTOM ROUTES HERE
+    for plugin in p.PluginImplementations(p.IRoutes):
+        map = plugin.before_map(map)
+
     # The ErrorController route (handles 404/500 error pages); it should
     # likely stay at the top, ensuring it can always be resolved.
     map.connect('/error/{action}', controller='error')
@@ -93,10 +97,6 @@ def make_map():
 
     map.connect('*url', controller='home', action='cors_options',
                 conditions=OPTIONS)
-
-    # CUSTOM ROUTES HERE
-    for plugin in p.PluginImplementations(p.IRoutes):
-        map = plugin.before_map(map)
 
     map.connect('home', '/', controller='home', action='index')
     map.connect('about', '/about', controller='home', action='about')


### PR DESCRIPTION
To enable custom error handling in case of runtime errors which results in internal server errors, the default error controller must be created after plugins custom routs. This makes plugins to have their own error controller.